### PR TITLE
Add profile picture support

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -189,16 +189,20 @@
                         <label class="block text-sm font-medium mb-2 text-purple-300">Username</label>
                         <input type="text" id="profile-username" class="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all">
                     </div>
-                    <div>
-                        <label class="block text-sm font-medium mb-2 text-purple-300">Password Baru (kosongkan jika tidak ingin mengubah)</label>
-                        <input type="password" id="profile-password" class="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all">
-                    </div>
-                    <div class="flex gap-3 pt-4">
-                        <button type="submit" class="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
-                            💾 Simpan
-                        </button>
-                        <button type="button" onclick="hideProfileEdit()" class="flex-1 bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
-                            ❌ Batal
+        <div>
+            <label class="block text-sm font-medium mb-2 text-purple-300">Password Baru (kosongkan jika tidak ingin mengubah)</label>
+            <input type="password" id="profile-password" class="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all">
+        </div>
+        <div>
+            <label class="block text-sm font-medium mb-2 text-purple-300">Foto Profil</label>
+            <input type="file" id="profile-picture" accept="image/*" class="w-full text-white" />
+        </div>
+        <div class="flex gap-3 pt-4">
+            <button type="submit" class="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
+                💾 Simpan
+            </button>
+            <button type="button" onclick="hideProfileEdit()" class="flex-1 bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
+                ❌ Batal
                         </button>
                     </div>
                 </form>
@@ -567,12 +571,17 @@
             const adminIcon = data.user.is_admin ? '<span class="text-red-400 text-xl ml-1">👑</span>' : '';
             
             document.getElementById('welcome-text').innerHTML = `
-                Selamat datang kembali, 
-                <span class="font-semibold text-purple-300">${data.user.username}</span> 
-                ${verifiedIcon} 
-                ${adminIcon}
-                <div class="flex flex-wrap gap-2 mt-2">
-                    ${badgeHtml}
+                <div class="flex items-center gap-4">
+                    ${data.user.profile_picture ? `<img src="${data.user.profile_picture}" class="w-12 h-12 rounded-full object-cover">` : `<div class="w-12 h-12 bg-gradient-to-r from-purple-500 to-blue-500 rounded-full flex items-center justify-center text-white font-bold">${data.user.username.charAt(0).toUpperCase()}</div>`}
+                    <div>
+                        Selamat datang kembali,
+                        <span class="font-semibold text-purple-300">${data.user.username}</span>
+                        ${verifiedIcon}
+                        ${adminIcon}
+                        <div class="flex flex-wrap gap-2 mt-2">
+                            ${badgeHtml}
+                        </div>
+                    </div>
                 </div>
             `;
 
@@ -819,7 +828,8 @@
             const name = document.getElementById('profile-name').value;
             const username = document.getElementById('profile-username').value;
             const password = document.getElementById('profile-password').value;
-            
+            const profilePic = document.getElementById('profile-picture').files[0];
+
             if (name) formData.append('name', name);
             if (username) formData.append('username', username);
             if (password) formData.append('password', password);
@@ -831,11 +841,20 @@
                     headers: { 'Authorization': `Bearer ${token}` },
                     body: formData
                 });
-                
+
                 const data = await response.json();
                 if (response.ok) {
                     if (data.new_token) {
                         localStorage.setItem('token', data.new_token);
+                    }
+                    if (profilePic) {
+                        const picForm = new FormData();
+                        picForm.append('file', profilePic);
+                        await fetch('/api/profile-picture', {
+                            method: 'POST',
+                            headers: { 'Authorization': `Bearer ${token}` },
+                            body: picForm
+                        });
                     }
                     alert('✅ Profil berhasil diperbarui!');
                     hideProfileEdit();

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -67,9 +67,13 @@
         <div class="bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 mb-8 border border-gray-700">
             <div class="flex flex-col space-y-4">
                 <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+                    {% if user.profile_picture %}
+                    <img src="{{ user.profile_picture }}" alt="{{ user.username }} profile picture" class="w-16 h-16 rounded-full object-cover flex-shrink-0">
+                    {% else %}
                     <div class="w-16 h-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-2xl font-bold flex-shrink-0">
                         {{ user.username[0].upper( ) }}
                     </div>
+                    {% endif %}
                     <div class="flex-1 min-w-0">
                         <div class="flex flex-wrap items-center gap-2 mb-2">
                             <h1 class="text-2xl font-bold truncate">{{ user.username }}</h1>

--- a/templates/users.html
+++ b/templates/users.html
@@ -84,9 +84,13 @@
             {% for user in users %}
                 <div class="user-card bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 border border-gray-700 hover:border-gray-600 transition-all">
                     <div class="flex items-center space-x-4 mb-4">
+                        {% if user.profile_picture %}
+                        <img src="{{ user.profile_picture }}" alt="{{ user.username }} profile picture" class="w-12 h-12 rounded-full object-cover">
+                        {% else %}
                         <div class="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-lg font-bold">
                             {{ user.username[0].upper() }}
                         </div>
+                        {% endif %}
                         <div class="flex-1">
                             <div class="flex items-center space-x-2 mb-1">
                                 <h3 class="font-semibold text-lg">


### PR DESCRIPTION
## Summary
- add profile picture upload endpoint and storage
- show profile pictures on dashboard, user profiles, and user list

## Testing
- `python -m py_compile main.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6a01effa08325a311da109b8ec952