### PR TITLE
Improve download extensions and profile picture management

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request, Depends, HTTPException, status, Form, File
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.staticfiles import StaticFiles
 import uuid
 import hashlib
 import secrets
@@ -51,6 +52,9 @@ os.makedirs("data/users", exist_ok=True)
 os.makedirs("data/codes", exist_ok=True)
 os.makedirs("data/threads", exist_ok=True)
 os.makedirs("data/notifications", exist_ok=True)
+os.makedirs("data/profile_pictures", exist_ok=True)
+
+app.mount("/profile_pictures", StaticFiles(directory="data/profile_pictures"), name="profile_pictures")
 
 def load_json_file(filepath: str) -> Dict[str, Any]:
     """Load JSON file, return empty dict if file doesn't exist"""
@@ -383,7 +387,8 @@ def get_all_users() -> List[Dict[str, Any]]:
                         "created_at": user_data.get("created_at"),
                         "badges": user_data.get("badges", []),
                         "is_admin": user_data.get("is_admin", False),
-                        "verified_by_admin": user_data.get("verified_by_admin", False)
+                        "verified_by_admin": user_data.get("verified_by_admin", False),
+                        "profile_picture": user_data.get("profile_picture")
                     }
                     users.append(safe_user)
     return sorted(users, key=lambda x: x.get("created_at", ""), reverse=True)
@@ -833,7 +838,8 @@ async def signup(
         "badges": ["newcomer"],
         "is_admin": False,
         "verified_by_admin": False,
-        "auth_provider": "local"
+        "auth_provider": "local",
+        "profile_picture": None
     }
     
     save_user(username, user_data)
@@ -894,82 +900,78 @@ async def create_paste(
         try:
             file_content = save_uploaded_file(file)
             final_content = file_content if not content else content + "\n\n" + file_content
-            
 
+            if language == "text" and file.filename:
+                ext = file.filename.split('.')[-1].lower()
+                language_map = {
+                    # Bahasa pemrograman populer
+                    'py': 'python',
+                    'js': 'javascript',
+                    'ts': 'typescript',
+                    'html': 'html',
+                    'htm': 'html',
+                    'css': 'css',
+                    'java': 'java',
+                    'cpp': 'cpp',
+                    'c': 'c',
+                    'cs': 'csharp',
+                    'rb': 'ruby',
+                    'php': 'php',
+                    'go': 'go',
+                    'rs': 'rust',
+                    'kt': 'kotlin',
+                    'swift': 'swift',
+                    'scala': 'scala',
+                    'dart': 'dart',
 
-try:
-    if language == "text" and file.filename:
-        ext = file.filename.split('.')[-1].lower()
-        language_map = {
-            # Bahasa pemrograman populer
-            'py': 'python',
-            'js': 'javascript',
-            'ts': 'typescript',
-            'html': 'html',
-            'htm': 'html',
-            'css': 'css',
-            'java': 'java',
-            'cpp': 'cpp',
-            'c': 'c',
-            'cs': 'csharp',
-            'rb': 'ruby',
-            'php': 'php',
-            'go': 'go',
-            'rs': 'rust',
-            'kt': 'kotlin',
-            'swift': 'swift',
-            'scala': 'scala',
-            'dart': 'dart',
+                    # Data & config
+                    'sql': 'sql',
+                    'json': 'json',
+                    'xml': 'xml',
+                    'yml': 'yaml',
+                    'yaml': 'yaml',
+                    'toml': 'toml',
+                    'ini': 'ini',
+                    'cfg': 'ini',
+                    'env': 'dotenv',
 
-            # Data & config
-            'sql': 'sql',
-            'json': 'json',
-            'xml': 'xml',
-            'yml': 'yaml',
-            'yaml': 'yaml',
-            'toml': 'toml',
-            'ini': 'ini',
-            'cfg': 'ini',
-            'env': 'dotenv',
+                    # Shell & scripting
+                    'sh': 'bash',
+                    'bash': 'bash',
+                    'ps1': 'powershell',
+                    'bat': 'batch',
+                    'cmd': 'batch',
 
-            # Shell & scripting
-            'sh': 'bash',
-            'bash': 'bash',
-            'ps1': 'powershell',
-            'bat': 'batch',
-            'cmd': 'batch',
+                    # Markup & docs
+                    'md': 'markdown',
+                    'markdown': 'markdown',
+                    'rst': 'rst',
+                    'tex': 'latex',
+                    'latex': 'latex',
 
-            # Markup & docs
-            'md': 'markdown',
-            'markdown': 'markdown',
-            'rst': 'rst',
-            'tex': 'latex',
-            'latex': 'latex',
+                    # Web & template
+                    'vue': 'vue',
+                    'svelte': 'svelte',
+                    'jsx': 'jsx',
+                    'tsx': 'tsx',
+                    'ejs': 'ejs',
+                    'twig': 'twig',
+                    'jinja': 'jinja',
 
-            # Web & template
-            'vue': 'vue',
-            'svelte': 'svelte',
-            'jsx': 'jsx',
-            'tsx': 'tsx',
-            'ejs': 'ejs',
-            'twig': 'twig',
-            'jinja': 'jinja',
+                    # Tambahan lain
+                    'pl': 'perl',
+                    'lua': 'lua',
+                    'r': 'r',
+                    'erl': 'erlang',
+                    'ex': 'elixir',
+                    'clj': 'clojure',
+                    'hs': 'haskell',
+                    'ml': 'ocaml'
+                }
 
-            # Tambahan lain
-            'pl': 'perl',
-            'lua': 'lua',
-            'r': 'r',
-            'erl': 'erlang',
-            'ex': 'elixir',
-            'clj': 'clojure',
-            'hs': 'haskell',
-            'ml': 'ocaml'
-        }
-
-        language = language_map.get(ext, 'text')
-
-except Exception as e:
-    raise HTTPException(status_code=400, detail=f"Error processing file: {str(e)}")
+                language = language_map.get(ext, 'text')
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Error processing file: {str(e)}")
 
     
     # Get user info
@@ -1054,7 +1056,12 @@ async def view_paste(
     
     # Get threads
     threads = get_threads_by_code_id(paste_id)
-    
+
+    # Include author profile picture if available
+    author_data = get_user_by_username(paste.get("author_username", ""))
+    if author_data:
+        paste["author_profile_picture"] = author_data.get("profile_picture")
+
     return templates.TemplateResponse("paste.html", {
         "request": request,
         "paste": paste,
@@ -1093,7 +1100,8 @@ async def api_dashboard(current_user: str = Depends(get_current_user)):
             "email": user_data["email"],
             "badges": user_data.get("badges", []),
             "verified_by_admin": user_data.get("verified_by_admin", False),
-            "is_admin": user_data.get("is_admin", False)
+            "is_admin": user_data.get("is_admin", False),
+            "profile_picture": user_data.get("profile_picture")
         },
         "pastes": user_pastes,
         "stats": {
@@ -1163,6 +1171,11 @@ async def view_paste(
     
     # Get threads
     threads = get_threads_by_code_id(paste_id)
+
+    # Include author profile picture if available
+    author_data = get_user_by_username(paste.get("author_username", ""))
+    if author_data:
+        paste["author_profile_picture"] = author_data.get("profile_picture")
 
     return templates.TemplateResponse("paste.html", {
         "request": request,
@@ -1286,7 +1299,8 @@ async def view_user_profile(username: str, request: Request):
             "badge_details": badge_details,
             "created_at": updated_user.get("created_at"),
             "is_admin": updated_user.get("is_admin", False),
-            "verified_by_admin": updated_user.get("verified_by_admin", False)
+            "verified_by_admin": updated_user.get("verified_by_admin", False),
+            "profile_picture": updated_user.get("profile_picture")
         },
         "pastes": user_codes,
         "current_user": current_user,
@@ -1333,6 +1347,7 @@ async def view_all_users(request: Request):
             "badge_details": badge_details,
             "is_admin": updated_user.get("is_admin", False),
             "verified_by_admin": updated_user.get("verified_by_admin", False),
+            "profile_picture": updated_user.get("profile_picture"),
             "paste_count": len(get_user_codes(user["username"]))
         })
     
@@ -1508,6 +1523,63 @@ async def get_admin_stats(current_user: str = Depends(get_current_user)):
     }
 
 # Profile editing endpoints
+
+@app.post("/api/profile-picture")
+async def upload_profile_picture(
+    file: UploadFile = File(...),
+    current_user: str = Depends(get_current_user)
+):
+    """Upload or update user's profile picture"""
+    allowed_extensions = {"png", "jpg", "jpeg", "gif"}
+    ext = file.filename.split(".")[-1].lower()
+    if ext not in allowed_extensions:
+        raise HTTPException(status_code=400, detail="Invalid image format")
+
+    content = await file.read()
+    if len(content) > 2 * 1024 * 1024:  # 2MB limit
+        raise HTTPException(status_code=400, detail="File too large (max 2MB)")
+
+    save_dir = "data/profile_pictures"
+    os.makedirs(save_dir, exist_ok=True)
+
+    # Remove old profile pictures with different extensions
+    for old_ext in allowed_extensions:
+        old_file = f"{save_dir}/{current_user}.{old_ext}"
+        if os.path.exists(old_file):
+            os.remove(old_file)
+
+    file_path = f"{save_dir}/{current_user}.{ext}"
+    with open(file_path, "wb") as buffer:
+        buffer.write(content)
+
+    user = get_user_by_username(current_user)
+    user["profile_picture"] = f"/profile_pictures/{current_user}.{ext}"
+    save_user(current_user, user)
+
+    return {"profile_picture": user["profile_picture"]}
+
+
+@app.delete("/api/profile-picture")
+async def delete_profile_picture(current_user: str = Depends(get_current_user)):
+    """Remove user's profile picture"""
+    allowed_extensions = {"png", "jpg", "jpeg", "gif"}
+    removed = False
+    for ext in allowed_extensions:
+        path = f"data/profile_pictures/{current_user}.{ext}"
+        if os.path.exists(path):
+            os.remove(path)
+            removed = True
+
+    user = get_user_by_username(current_user)
+    if user.get("profile_picture"):
+        user["profile_picture"] = None
+        save_user(current_user, user)
+
+    if not removed:
+        raise HTTPException(status_code=404, detail="No profile picture found")
+
+    return {"message": "Profile picture deleted"}
+
 @app.post("/api/profile/update")
 async def update_profile(
     name: Optional[str] = Form(default=None),
@@ -1538,12 +1610,24 @@ async def update_profile(
         # Save user with new username
         save_user(username, user)
         user["username"] = username
-        
+
         # Delete old user file
         old_filepath = f"data/users/{current_user}.json"
         if os.path.exists(old_filepath):
             os.remove(old_filepath)
-        
+
+        # Rename profile picture if exists
+        if user.get("profile_picture"):
+            old_base = f"data/profile_pictures/{current_user}"
+            for ext in ("png", "jpg", "jpeg", "gif"):
+                old_file = f"{old_base}.{ext}"
+                if os.path.exists(old_file):
+                    new_file = f"data/profile_pictures/{username}.{ext}"
+                    os.rename(old_file, new_file)
+                    user["profile_picture"] = f"/profile_pictures/{username}.{ext}"
+                    save_user(username, user)
+                    break
+
         # Update all pastes with new username
         if os.path.exists("data/codes"):
             for filename in os.listdir("data/codes"):

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -189,18 +189,25 @@
                         <label class="block text-sm font-medium mb-2 text-purple-300">Username</label>
                         <input type="text" id="profile-username" class="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all">
                     </div>
-                    <div>
-                        <label class="block text-sm font-medium mb-2 text-purple-300">Password Baru (kosongkan jika tidak ingin mengubah)</label>
-                        <input type="password" id="profile-password" class="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all">
-                    </div>
-                    <div class="flex gap-3 pt-4">
-                        <button type="submit" class="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
-                            💾 Simpan
-                        </button>
-                        <button type="button" onclick="hideProfileEdit()" class="flex-1 bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
-                            ❌ Batal
-                        </button>
-                    </div>
+        <div>
+            <label class="block text-sm font-medium mb-2 text-purple-300">Password Baru (kosongkan jika tidak ingin mengubah)</label>
+            <input type="password" id="profile-password" class="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all">
+        </div>
+        <div>
+            <label class="block text-sm font-medium mb-2 text-purple-300">Foto Profil</label>
+            <input type="file" id="profile-picture" accept="image/*" class="w-full text-white" />
+        </div>
+        <div class="flex gap-3 pt-4">
+            <button type="submit" class="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
+                💾 Simpan
+            </button>
+            <button type="button" onclick="removeProfilePicture()" class="flex-1 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
+                🗑️ Hapus Foto
+            </button>
+            <button type="button" onclick="hideProfileEdit()" class="flex-1 bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 px-6 py-2 rounded-lg transition-all font-medium shadow-lg">
+                ❌ Batal
+            </button>
+        </div>
                 </form>
             </div>
         </div>
@@ -567,12 +574,17 @@
             const adminIcon = data.user.is_admin ? '<span class="text-red-400 text-xl ml-1">👑</span>' : '';
             
             document.getElementById('welcome-text').innerHTML = `
-                Selamat datang kembali, 
-                <span class="font-semibold text-purple-300">${data.user.username}</span> 
-                ${verifiedIcon} 
-                ${adminIcon}
-                <div class="flex flex-wrap gap-2 mt-2">
-                    ${badgeHtml}
+                <div class="flex items-center gap-4">
+                    ${data.user.profile_picture ? `<img src="${data.user.profile_picture}" class="w-12 h-12 rounded-full object-cover">` : `<div class="w-12 h-12 bg-gradient-to-r from-purple-500 to-blue-500 rounded-full flex items-center justify-center text-white font-bold">${data.user.username.charAt(0).toUpperCase()}</div>`}
+                    <div>
+                        Selamat datang kembali,
+                        <span class="font-semibold text-purple-300">${data.user.username}</span>
+                        ${verifiedIcon}
+                        ${adminIcon}
+                        <div class="flex flex-wrap gap-2 mt-2">
+                            ${badgeHtml}
+                        </div>
+                    </div>
                 </div>
             `;
 
@@ -812,6 +824,29 @@
             document.getElementById('profile-modal').classList.add('hidden');
         }
 
+        async function removeProfilePicture() {
+            if (!confirm('Hapus foto profil?')) return;
+            const token = localStorage.getItem('token');
+            try {
+                const response = await fetch('/api/profile-picture', {
+                    method: 'DELETE',
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+                const data = await response.json();
+                if (response.ok) {
+                    alert('✅ Foto profil dihapus');
+                    document.getElementById('profile-picture').value = '';
+                    hideProfileEdit();
+                    loadDashboard();
+                } else {
+                    alert('❌ ' + (data.detail || 'Gagal menghapus foto profil'));
+                }
+            } catch (error) {
+                console.error('Error deleting profile picture:', error);
+                alert('❌ Terjadi kesalahan saat menghapus foto profil');
+            }
+        }
+
         document.getElementById('profile-form').addEventListener('submit', async (e) => {
             e.preventDefault();
             
@@ -819,7 +854,8 @@
             const name = document.getElementById('profile-name').value;
             const username = document.getElementById('profile-username').value;
             const password = document.getElementById('profile-password').value;
-            
+            const profilePic = document.getElementById('profile-picture').files[0];
+
             if (name) formData.append('name', name);
             if (username) formData.append('username', username);
             if (password) formData.append('password', password);
@@ -831,11 +867,20 @@
                     headers: { 'Authorization': `Bearer ${token}` },
                     body: formData
                 });
-                
+
                 const data = await response.json();
                 if (response.ok) {
                     if (data.new_token) {
                         localStorage.setItem('token', data.new_token);
+                    }
+                    if (profilePic) {
+                        const picForm = new FormData();
+                        picForm.append('file', profilePic);
+                        await fetch('/api/profile-picture', {
+                            method: 'POST',
+                            headers: { 'Authorization': `Bearer ${token}` },
+                            body: picForm
+                        });
                     }
                     alert('✅ Profil berhasil diperbarui!');
                     hideProfileEdit();

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -65,9 +65,13 @@
                     <h1 class="text-2xl sm:text-3xl font-bold text-white mb-3">{{ paste.title }}</h1>
                     <div class="flex flex-wrap items-center gap-3 text-sm">
                         <div class="flex items-center gap-2">
+                            {% if paste.author_profile_picture %}
+                            <img src="{{ paste.author_profile_picture }}" alt="{{ paste.author_username }} profile picture" class="w-8 h-8 rounded-full object-cover">
+                            {% else %}
                             <div class="w-8 h-8 bg-gradient-to-r from-purple-500 to-blue-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
                                 {{ paste.author_username[0].upper() }}
                             </div>
+                            {% endif %}
                             <span class="text-blue-300 flex items-center gap-1">
                                 {{ paste.author_username }}
                                 {% if paste.author_is_verified %}
@@ -118,6 +122,9 @@
                     <button onclick="copyCode()" class="bg-green-600 hover:bg-green-700 px-3 py-2 rounded-lg text-sm transition-all">
                         📋 Salin Kode
                     </button>
+                    <button onclick="downloadCode()" class="bg-gray-700 hover:bg-gray-600 px-3 py-2 rounded-lg text-sm transition-all">
+                        ⬇️ Unduh Kode
+                    </button>
                     <button onclick="copyURL()" class="bg-gray-700 hover:bg-gray-600 px-3 py-2 rounded-lg text-sm transition-all">
                         🔗 Salin URL
                     </button>
@@ -125,7 +132,7 @@
             </div>
             
             <div class="bg-gray-900/80 rounded-lg p-4 overflow-x-auto">
-                <pre><code class="language-{{ paste.language }}">{{ paste.content }}</code></pre>
+                <pre><code id="pasteCode" class="language-{{ paste.language }}">{{ paste.content }}</code></pre>
             </div>
         </div>
         
@@ -179,13 +186,50 @@
             });
         }
 
+        function downloadCode() {
+            const codeElement = document.getElementById('pasteCode');
+            if (!codeElement) {
+                alert('Kode tidak ditemukan');
+                return;
+            }
+            const content = codeElement.textContent || codeElement.innerText;
+
+            const lang = "{{ paste.language }}";
+            const extensions = {
+                python: 'py',
+                javascript: 'js',
+                typescript: 'ts',
+                java: 'java',
+                c: 'c',
+                cpp: 'cpp',
+                csharp: 'cs',
+                ruby: 'rb',
+                go: 'go',
+                php: 'php',
+                html: 'html',
+                css: 'css',
+                text: 'txt'
+            };
+            const ext = extensions[lang] || lang;
+            const filename = "{{ (paste.title or 'code')|replace(' ', '_') }}." + ext;
+
+            const blob = new Blob([content], { type: 'text/plain' });
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = filename;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(link.href);
+        }
+
         function logout() {
             localStorage.removeItem('token');
             window.location.href = '/login';
         }
 
         function copyCode() {
-            const codeElement = document.querySelector('pre code');
+            const codeElement = document.getElementById('pasteCode');
             if (!codeElement) {
                 alert('Kode tidak ditemukan');
                 return;

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -67,9 +67,13 @@
         <div class="bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 mb-8 border border-gray-700">
             <div class="flex flex-col space-y-4">
                 <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+                    {% if user.profile_picture %}
+                    <img src="{{ user.profile_picture }}" alt="{{ user.username }} profile picture" class="w-16 h-16 rounded-full object-cover flex-shrink-0">
+                    {% else %}
                     <div class="w-16 h-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-2xl font-bold flex-shrink-0">
                         {{ user.username[0].upper( ) }}
                     </div>
+                    {% endif %}
                     <div class="flex-1 min-w-0">
                         <div class="flex flex-wrap items-center gap-2 mb-2">
                             <h1 class="text-2xl font-bold truncate">{{ user.username }}</h1>

--- a/templates/users.html
+++ b/templates/users.html
@@ -84,9 +84,13 @@
             {% for user in users %}
                 <div class="user-card bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 border border-gray-700 hover:border-gray-600 transition-all">
                     <div class="flex items-center space-x-4 mb-4">
+                        {% if user.profile_picture %}
+                        <img src="{{ user.profile_picture }}" alt="{{ user.username }} profile picture" class="w-12 h-12 rounded-full object-cover">
+                        {% else %}
                         <div class="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-lg font-bold">
                             {{ user.username[0].upper() }}
                         </div>
+                        {% endif %}
                         <div class="flex-1">
                             <div class="flex items-center space-x-2 mb-1">
                                 <h3 class="font-semibold text-lg">


### PR DESCRIPTION
## Summary
- Map paste languages to standard file extensions during download
- Enable replacing and deleting profile pictures with size validation and cleanup
- Add dashboard controls for removing avatars

## Testing
- `python -m py_compile main.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6a01effa08325a311da109b8ec952